### PR TITLE
DescribeTypeRTTIReflector: fix injected variables with types in the openfl.* package when using OpenFL's "flash" target

### DIFF
--- a/src/org/swiftsuspenders/reflection/DescribeTypeRTTIReflector.hx
+++ b/src/org/swiftsuspenders/reflection/DescribeTypeRTTIReflector.hx
@@ -322,8 +322,17 @@ class DescribeTypeRTTIReflector implements Reflector {
 		for (elem in _currentFactoryXMLFast.elements) {
 			if (elem.name == propertyName) {
 				var pathFast = new Access(elem.x.firstElement());
-				if (pathFast.has.path)
+				if (pathFast.has.path) {
 					value = pathFast.att.path;
+					#if (openfl && flash)
+					// when targeting flash, if the openfl package is
+					// encountered in rtti, use the flash package instead
+					// example: openfl.events.IEventDispatcher should become flash.events.IEventDispatcher
+					if (StringTools.startsWith(value, "openfl.")) {
+						value = "flash." + value.substr(7);
+					}
+					#end
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
The injector's generated `mappingId` for `flash.events.IEventDispatcher` is "flash.events.IEventDispatcher|", but the generated `mappingId` from `DescribeTypeRTTIReflector` was "openfl.events.IEventDispatcher|" instead. This pull request ensures that both generated ids are "flash.events.IEventDispatcher|".

Basically, it fixes the need to write code like below in a cross-platform OpenFL project that needs to support multiple targets including AIR.

```haxe
#if flash
import flash.events.IEventDispatcher;
#else
import openfl.events.IEventDispatcher;
#end
```

```hx
@inject public var dispatcher:IEventDispatcher;
```